### PR TITLE
ci: run tests in other platforms (windows, wasm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,14 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: "${{ matrix.platform.os }}-latest"
+    strategy:
+      matrix:
+        platform: [
+          { os: "windows", target: "x86_64-pc-windows-msvc" },
+          { os: "ubuntu", target: "x86_64-unknown-linux-gnu" },
+          { os: "ubuntu", target: "wasm32-unknown-unknown" },
+        ]
     steps:
       - uses: actions/checkout@v2
       - name: Cache .cargo and target
@@ -23,15 +30,23 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          target: ${{ matrix.platform.target }}
           profile: minimal
           default: true
+      - name: Install test runner for wasm
+        if: matrix.platform.target == 'wasm32-unknown-unknown'
+        run:  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Stable Build
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-features
+          args: --all-features --target ${{ matrix.platform.target }}
       - name: Tests
+        if: matrix.platform.target != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features
+      - name: Tests in WASM
+        if: matrix.platform.target == 'wasm32-unknown-unknown'
+        run: wasm-pack test --node -- --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2018"
 
 [dependencies]
 thiserror = "1.0.24"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"


### PR DESCRIPTION
## Change Summary
This adds to the CI, a worker to run the tests with Windows and also using wasm-pack for WASM.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
