### PR TITLE
feat: create Client and ClientBuilder structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait = "0.1.50"
+bytes = "1.0.1"
 http = "0.2.4"
 thiserror = "1.0.24"
 

--- a/mocks/get_api_key_header.yaml
+++ b/mocks/get_api_key_header.yaml
@@ -1,0 +1,14 @@
+when:
+  method: GET
+  path: /test_api_key
+  header:
+    - name: X-TYPESENSE-API-KEY
+      value: VerySecretKey
+then:
+  status: 200
+  header:
+    - name: content-type
+      value: text/html
+    - name: Access-Control-Allow-Origin
+      value: \*
+  body: "Test with api key successful"

--- a/mocks/post_api_key.yaml
+++ b/mocks/post_api_key.yaml
@@ -1,0 +1,13 @@
+when:
+  method: POST
+  path: /test_api_key
+  header:
+    - name: X-TYPESENSE-API-KEY
+      value: VerySecretKey
+  body: "Test with api key successful"
+then:
+  status: 200
+  header:
+    - name: content-type
+      value: text/html
+  body: "Test with api key successful"

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -64,20 +64,28 @@ impl<'a, T> Default for ClientBuilder<'a, T> {
     doc(cfg(all(feature = "tokio-rt", not(target_arch = "wasm32"))))
 )]
 impl<'a> ClientBuilder<'a, crate::transport::HyperHttpsClient> {
-    /// Set transport with a new [`hyper`](https://docs.rs/hyper) client.
+    /// Create client builder with a [`hyper`](https://docs.rs/hyper) client.
     /// The connector used is [`HttpsConnector`](hyper_tls::HttpsConnector).
-    pub fn with_hyper(mut self) -> Self {
-        self.transport = Some(crate::transport::TransportBuilder::new_hyper().build());
-        self
+    pub fn new_hyper() -> Self {
+        let transport = Some(crate::transport::TransportBuilder::new_hyper().build());
+        Self {
+            transport,
+            host: None,
+            api_key: None,
+        }
     }
 }
 
 #[cfg(target_arch = "wasm32")]
 #[cfg_attr(docsrs, doc(cfg(target_arch = "wasm32")))]
 impl<'a> ClientBuilder<'a, WasmClient> {
-    /// Set transport using default wasm client
-    pub fn with_wasm(mut self) -> Self {
-        self.transport = Some(crate::transport::TransportBuilder::new_wasm().build());
-        self
+    /// Create client builder using default wasm client
+    pub fn new_wasm() -> Self {
+        let transport = Some(crate::transport::TransportBuilder::new_wasm().build());
+        Self {
+            transport,
+            host: None,
+            api_key: None,
+        }
     }
 }

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,0 +1,83 @@
+use super::Client;
+use crate::transport::Transport;
+
+#[cfg(target_arch = "wasm32")]
+use crate::transport::WasmClient;
+
+use crate::{Result, TypesenseError};
+/// Builder for the Typesense [`Client`]
+pub struct ClientBuilder<'a, T> {
+    transport: Option<Transport<T>>,
+    host: Option<&'a str>,
+    api_key: Option<&'a str>,
+}
+
+impl<'a, T> ClientBuilder<'a, T> {
+    /// build [`Client`] with the current configurations. Return [`typesense::TypesenseError::ConfigError`]
+    /// if a configuration is missing.
+    pub fn build(self) -> Result<Client<'a, T>> {
+        Ok(Client {
+            transport: self.transport.ok_or_else(|| {
+                TypesenseError::ConfigError("missing client transport".to_string())
+            })?,
+            host: self
+                .host
+                .ok_or_else(|| TypesenseError::ConfigError("missing client host".to_string()))?,
+            api_key: self
+                .api_key
+                .ok_or_else(|| TypesenseError::ConfigError("missing client api key".to_string()))?,
+        })
+    }
+
+    /// Set host
+    pub fn host(mut self, host: &'a str) -> Self {
+        self.host = Some(host);
+        self
+    }
+
+    /// Set api key
+    pub fn api_key(mut self, api_key: &'a str) -> Self {
+        self.api_key = Some(api_key);
+        self
+    }
+
+    /// Set transport
+    pub fn transport(mut self, transport: Transport<T>) -> Self {
+        self.transport = Some(transport);
+        self
+    }
+}
+
+impl<'a, T> Default for ClientBuilder<'a, T> {
+    fn default() -> Self {
+        Self {
+            transport: None,
+            host: None,
+            api_key: None,
+        }
+    }
+}
+
+#[cfg(all(feature = "tokio-rt", not(target_arch = "wasm32")))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "tokio-rt", not(target_arch = "wasm32"))))
+)]
+impl<'a> ClientBuilder<'a, crate::transport::HyperHttpsClient> {
+    /// Set transport with a new [`hyper`](https://docs.rs/hyper) client.
+    /// The connector used is [`HttpsConnector`](hyper_tls::HttpsConnector).
+    pub fn with_hyper(mut self) -> Self {
+        self.transport = Some(crate::transport::TransportBuilder::new_hyper().build());
+        self
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[cfg_attr(docsrs, doc(cfg(target_arch = "wasm32")))]
+impl<'a> ClientBuilder<'a, WasmClient> {
+    /// Set transport using default wasm client
+    pub fn with_wasm(mut self) -> Self {
+        self.transport = Some(crate::transport::TransportBuilder::new_wasm().build());
+        self
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -110,10 +110,9 @@ mod hyper_tests {
         let host = "http://localhost:5000";
         let api_key = "VerySecretKey";
 
-        let client = ClientBuilder::default()
+        let client = ClientBuilder::new_hyper()
             .host(host)
             .api_key(api_key)
-            .with_hyper()
             .build()
             .unwrap();
 
@@ -174,10 +173,9 @@ mod wasm_test {
         let host = "http://localhost:5000";
         let api_key = "VerySecretKey";
 
-        let client = ClientBuilder::default()
+        let client = ClientBuilder::new_wasm()
             .host(host)
             .api_key(api_key)
-            .with_wasm()
             .build()
             .unwrap();
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,0 +1,198 @@
+use crate::transport::Transport;
+use crate::Result;
+
+#[cfg(target_arch = "wasm32")]
+use crate::transport::WasmClient;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::transport::HyperClient;
+
+mod builder;
+pub use builder::ClientBuilder;
+
+#[allow(dead_code)]
+pub const TYPESENSE_API_KEY_HEADER_NAME: &str = "X-TYPESENSE-API-KEY";
+
+/// Root client for top level APIs
+pub struct Client<'a, T> {
+    transport: Transport<T>,
+    host: &'a str,
+    api_key: &'a str,
+}
+
+impl<'a, T> Client<'a, T> {
+    /// Gets the transport of the client
+    pub fn transport(&self) -> &Transport<T> {
+        &self.transport
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(dead_code)]
+impl<'a, C> Client<'a, HyperClient<C>>
+where
+    C: hyper::client::connect::Connect + Clone + Send + Sync + 'static,
+{
+    pub(crate) async fn send(
+        &self,
+        method: http::Method,
+        path: &str,
+        mut headers: http::HeaderMap,
+        body: Vec<u8>,
+    ) -> Result<http::Response<hyper::Body>> {
+        let uri = format!("{}{}", self.host, path);
+        headers.insert(TYPESENSE_API_KEY_HEADER_NAME, self.api_key.parse().unwrap());
+        self.transport.send(method, &uri, headers, body).await
+    }
+
+    pub(crate) async fn get(
+        &self,
+        path: &str,
+        headers: http::HeaderMap,
+    ) -> Result<http::Response<hyper::Body>> {
+        self.send(http::Method::GET, path, headers, vec![]).await
+    }
+
+    pub(crate) async fn post(
+        &self,
+        path: &str,
+        headers: http::HeaderMap,
+        body: Vec<u8>,
+    ) -> Result<http::Response<hyper::Body>> {
+        self.send(http::Method::POST, path, headers, body).await
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[allow(dead_code)]
+impl<'a> Client<'a, WasmClient> {
+    pub(crate) async fn send(
+        &self,
+        method: http::Method,
+        path: &str,
+        mut headers: http::HeaderMap,
+        body: Vec<u8>,
+    ) -> Result<http::Response<Vec<u8>>> {
+        let uri = format!("{}{}", self.host, path);
+        headers.insert(TYPESENSE_API_KEY_HEADER_NAME, self.api_key.parse().unwrap());
+        self.transport.send(method, &uri, headers, body).await
+    }
+
+    pub(crate) async fn get(
+        &self,
+        path: &str,
+        headers: http::HeaderMap,
+    ) -> Result<http::Response<Vec<u8>>> {
+        self.send(http::Method::GET, path, headers, vec![]).await
+    }
+
+    pub(crate) async fn post(
+        &self,
+        path: &str,
+        headers: http::HeaderMap,
+        body: Vec<u8>,
+    ) -> Result<http::Response<Vec<u8>>> {
+        self.send(http::Method::POST, path, headers, body).await
+    }
+}
+
+#[cfg(all(test, feature = "tokio-rt", not(target_arch = "wasm32")))]
+mod hyper_tests {
+    use http::{HeaderMap, StatusCode};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn hyper() -> crate::Result<()> {
+        let body = String::from("Test with api key successful");
+        let header = HeaderMap::new();
+
+        let host = "http://localhost:5000";
+        let api_key = "VerySecretKey";
+
+        let client = ClientBuilder::default()
+            .host(host)
+            .api_key(api_key)
+            .with_hyper()
+            .build()
+            .unwrap();
+
+        let response = client.get("/test_api_key", header.clone()).await?;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = hyper::body::to_bytes(response).await?;
+        assert_eq!(bytes, body.as_bytes());
+
+        let response = client
+            .post("/test_api_key", header.clone(), body.clone().into())
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = hyper::body::to_bytes(response).await?;
+        assert_eq!(bytes, body.as_bytes());
+
+        Ok(())
+    }
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod wasm_test {
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    use http::{HeaderMap, StatusCode};
+    use wasm_bindgen::prelude::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    use super::*;
+
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(js_namespace = console)]
+        fn log(s: &str);
+    }
+
+    macro_rules! console_log {
+        ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
+    }
+
+    #[wasm_bindgen_test]
+    async fn wasm() {
+        console_error_panic_hook::set_once();
+
+        console_log!("Test Started.");
+        match try_wasm().await {
+            Ok(_) => console_log!("Test Successful."),
+            Err(e) => console_log!("Test failed: {:?}", e),
+        }
+    }
+
+    async fn try_wasm() -> crate::Result<()> {
+        let body = String::from("Test with api key successful");
+
+        let header = HeaderMap::new();
+
+        let host = "http://localhost:5000";
+        let api_key = "VerySecretKey";
+
+        let client = ClientBuilder::default()
+            .host(host)
+            .api_key(api_key)
+            .with_wasm()
+            .build()
+            .unwrap();
+
+        let response = client.get("/test_api_key", header.clone()).await?;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.body(), body.as_bytes());
+
+        let response = client
+            .post("/test_api_key", header.clone(), body.clone().into())
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.body(), body.as_bytes());
+
+        Ok(())
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,3 +1,5 @@
+use bytes::Bytes;
+
 use crate::transport::HttpLowLevel;
 use crate::transport::Transport;
 use crate::Result;
@@ -31,7 +33,7 @@ where
         &self,
         method: http::Method,
         path: &str,
-        body: Vec<u8>,
+        body: Bytes,
     ) -> Result<C::Response> {
         let uri = format!("{}{}", self.host, path);
         let mut headers = http::HeaderMap::default();
@@ -40,10 +42,10 @@ where
     }
 
     pub(crate) async fn get(&self, path: &str) -> Result<C::Response> {
-        self.send(http::Method::GET, path, vec![]).await
+        self.send(http::Method::GET, path, Bytes::new()).await
     }
 
-    pub(crate) async fn post(&self, path: &str, body: Vec<u8>) -> Result<C::Response> {
+    pub(crate) async fn post(&self, path: &str, body: Bytes) -> Result<C::Response> {
         self.send(http::Method::POST, path, body).await
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 pub type Result<T> = std::result::Result<T, TypesenseError>;
 
 /// Represents an error that can occur while using the library.
+#[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum TypesenseError {
     /// TypesenseClientError
@@ -13,8 +14,8 @@ pub enum TypesenseError {
     TypesenseClientError,
 
     /// Config error.
-    #[error("config error")]
-    ConfigError,
+    #[error("config error: {0}")]
+    ConfigError(String),
 
     /// Timeout.
     #[error("timeout")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@
 //!
 //! Welcome to typesense, the rust library for the Typesense API.
 
+mod client;
 mod error;
 pub mod transport;
 
+pub use client::{Client, ClientBuilder};
 pub use error::{Result, TypesenseError};

--- a/src/transport/http_low_level.rs
+++ b/src/transport/http_low_level.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use bytes::Bytes;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) type HyperClient<C> = hyper::Client<C, hyper::Body>;
@@ -14,7 +15,7 @@ pub(crate) struct WasmClient;
 
 /// A low level HTTP trait.
 #[async_trait(?Send)]
-pub trait HttpLowLevel<M = http::Method, H = http::HeaderMap, B = Vec<u8>> {
+pub trait HttpLowLevel<M = http::Method, H = http::HeaderMap> {
     /// HTTP Response type.
     type Response;
 
@@ -24,7 +25,7 @@ pub trait HttpLowLevel<M = http::Method, H = http::HeaderMap, B = Vec<u8>> {
         method: M,
         uri: &str,
         headers: H,
-        body: B,
+        body: Bytes,
     ) -> crate::Result<Self::Response>;
 }
 
@@ -41,7 +42,7 @@ where
         method: http::Method,
         uri: &str,
         headers: http::HeaderMap,
-        body: Vec<u8>,
+        body: Bytes,
     ) -> crate::Result<Self::Response> {
         // Making a builder
         let mut builder = http::Request::builder().method(method).uri(uri);
@@ -73,7 +74,7 @@ impl HttpLowLevel for WasmClient {
         method: http::Method,
         uri: &str,
         headers: http::HeaderMap,
-        body: Vec<u8>,
+        body: Bytes,
     ) -> crate::Result<Self::Response> {
         use js_sys::{Array, ArrayBuffer, Reflect, Uint8Array};
         use wasm_bindgen::JsCast;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,5 +1,6 @@
 //! The module containing the [`Transport`] struct and
 //! its [`Builder`](TransportBuilder).
+use bytes::Bytes;
 
 mod builder;
 mod http_low_level;
@@ -37,7 +38,7 @@ where
         method: http::Method,
         uri: &str,
         headers: http::HeaderMap,
-        body: Vec<u8>,
+        body: Bytes,
     ) -> crate::Result<C::Response> {
         self.client.send(method, uri, headers, body).await
     }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -10,9 +10,6 @@ pub use http_low_level::HttpLowLevel;
 #[cfg(target_arch = "wasm32")]
 pub(crate) use http_low_level::WasmClient;
 
-#[cfg(not(target_arch = "wasm32"))]
-pub(crate) use http_low_level::HyperClient;
-
 #[cfg(all(feature = "tokio-rt", not(target_arch = "wasm32")))]
 pub(crate) use http_low_level::HyperHttpsClient;
 
@@ -37,10 +34,10 @@ where
     /// Send a request and receive a response.
     pub async fn send(
         &self,
-        method: C::Method,
+        method: http::Method,
         uri: &str,
-        headers: C::HeaderMap,
-        body: C::Body,
+        headers: http::HeaderMap,
+        body: Vec<u8>,
     ) -> crate::Result<C::Response> {
         self.client.send(method, uri, headers, body).await
     }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -7,6 +7,15 @@ mod http_low_level;
 pub use builder::TransportBuilder;
 pub use http_low_level::HttpLowLevel;
 
+#[cfg(target_arch = "wasm32")]
+pub(crate) use http_low_level::WasmClient;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use http_low_level::HyperClient;
+
+#[cfg(all(feature = "tokio-rt", not(target_arch = "wasm32")))]
+pub(crate) use http_low_level::HyperHttpsClient;
+
 /// The [`Transport`] struct.
 ///
 /// It handles the low level HTTP client.


### PR DESCRIPTION
## Change Summary

Added root client for the library. We should use this client to access the other API.

With something like this:

fn collection<T: Document>(&self) -> CollectionClient
fn operations(&self) -> OperationsClient
fn aliases(&self) -> AliasClient

Should solve #5

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
