### PR TITLE
Proc macro `typesense_derive`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,5 +60,5 @@ jobs:
           args: --all-features
       - name: Tests in WASM
         if: matrix.platform.target == 'wasm32-unknown-unknown'
-        run: wasm-pack test --headless --chrome
+        run: RUST_LOG=wasm_bindgen_test_runner wasm-pack test --headless --chrome
         working-directory: ./typesense

--- a/README.md
+++ b/README.md
@@ -5,4 +5,14 @@
 
 Rust client for Typesense | Work In Progress &amp; Help Wanted!
 
+Codegen was generated with:
+
+```
+docker run --rm \
+    -v $PWD:/local openapitools/openapi-generator-cli generate \
+    -i /local/openapi.yml \
+    -g rust \
+    -o /local/typesense_codegen_new
+```
+
 If you'd like to contribute, please join our [Slack Community](https://join.slack.com/t/typesense-community/shared_invite/zt-mx4nbsbn-AuOL89O7iBtvkz136egSJg) and say hello! 

--- a/mocks/get.yaml
+++ b/mocks/get.yaml
@@ -9,6 +9,4 @@ then:
   header:
     - name: content-type
       value: text/html
-    - name: Access-Control-Allow-Origin
-      value: \*
   body: "Test Successful"

--- a/mocks/get_api_key_header.yaml
+++ b/mocks/get_api_key_header.yaml
@@ -9,6 +9,4 @@ then:
   header:
     - name: content-type
       value: text/html
-    - name: Access-Control-Allow-Origin
-      value: \*
   body: "Test with api key successful"

--- a/mocks/retrieve_all_collections.yaml
+++ b/mocks/retrieve_all_collections.yaml
@@ -18,7 +18,8 @@ then:
       {"name": "num_employees", "type": "int32"},
       {"name": "country", "type": "string", "facet": true}
     ],
-    "default_sorting_field": "num_employees"
+    "default_sorting_field": "num_employees",
+    "created_at": 0
   },
   {
     "num_documents": 1250,
@@ -28,5 +29,6 @@ then:
       {"name": "full_name", "type": "string"},
       {"name": "from_year", "type": "int32"}
     ],
-    "default_sorting_field": "num_employees"
+    "default_sorting_field": "num_employees",
+    "created_at": 0
   }]'

--- a/typesense/src/client/mod.rs
+++ b/typesense/src/client/mod.rs
@@ -1,7 +1,9 @@
 use http::Response;
 
 use crate::collection::CollectionClient;
-use crate::transport::{HttpLowLevel, Transport, TransportCreator};
+#[allow(unused_imports)]
+use crate::transport::TransportCreator;
+use crate::transport::{HttpLowLevel, Transport};
 use crate::Result;
 
 #[cfg(target_arch = "wasm32")]

--- a/typesense/src/client/mod.rs
+++ b/typesense/src/client/mod.rs
@@ -23,6 +23,7 @@ pub struct Client<C> {
 
 impl<C> Client<C> {
     /// Gets the transport of the client
+    #[inline]
     pub fn transport(&self) -> &Transport<C> {
         &self.transport
     }
@@ -35,11 +36,10 @@ where
     Transport<C>: TransportCreator,
 {
     /// Create Client
+    #[inline]
     pub fn new(host: impl Into<String>, api_key: impl Into<String>) -> Self {
-        let transport = crate::transport::Transport::new();
-
         Self {
-            transport,
+            transport: Transport::new(),
             host: host.into(),
             api_key: api_key.into(),
         }
@@ -48,11 +48,13 @@ where
 
 impl<T> Client<T> {
     /// Make the ClientKeys struct, to interact with the Keys API.
+    #[inline]
     pub fn keys(&self) -> ClientKeys<'_, T> {
         ClientKeys { client: self }
     }
 
     /// Creates a [`CollectionClient`] to interact with the Typesense Collection API
+    #[inline]
     pub fn collection(&self) -> CollectionClient<'_, T> {
         CollectionClient { client: self }
     }
@@ -75,14 +77,17 @@ where
         self.transport.send(method, &uri, headers, body).await
     }
 
+    #[inline]
     pub(crate) async fn get(&self, path: &str) -> Result<Response<Vec<u8>>> {
         self.send(http::Method::GET, path, Vec::new()).await
     }
 
+    #[inline]
     pub(crate) async fn post(&self, path: &str, body: Vec<u8>) -> Result<Response<Vec<u8>>> {
         self.send(http::Method::POST, path, body).await
     }
 
+    #[inline]
     pub(crate) async fn delete(&self, path: &str) -> Result<Response<Vec<u8>>> {
         self.send(http::Method::DELETE, path, Vec::new()).await
     }

--- a/typesense/src/collection/schema.rs
+++ b/typesense/src/collection/schema.rs
@@ -12,44 +12,74 @@ pub struct CollectionSchemaBuilder {
     name: String,
     fields: Vec<Field>,
     default_sorting_field: Option<String>,
+    token_separators: Option<Vec<String>>,
+    enable_nested_fields: Option<bool>,
+    symbols_to_index: Option<Vec<String>>,
 }
 
 impl CollectionSchemaBuilder {
     /// Create a builder for [CollectionSchema]
+    #[inline]
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
             ..Default::default()
         }
     }
+
     /// Insert field
+    #[inline]
     pub fn field(mut self, field: Field) -> Self {
         self.fields.push(field);
         self
     }
 
     /// Set fields
+    #[inline]
     pub fn fields(mut self, fields: &[Field]) -> Self {
         self.fields.extend_from_slice(fields);
         self
     }
 
-    /// Set default_sorting_field
+    /// Set default sorting field
+    #[inline]
     pub fn default_sorting_field(mut self, default_sorting_field: String) -> Self {
         self.default_sorting_field = Some(default_sorting_field);
         self
     }
 
+    /// Set token separators
+    #[inline]
+    pub fn token_separators(mut self, token_separators: Vec<String>) -> Self {
+        self.token_separators = Some(token_separators);
+        self
+    }
+
+    /// Enable nested fields
+    #[inline]
+    pub fn enable_nested_fields(mut self, enable_nested_fields: Option<bool>) -> Self {
+        self.enable_nested_fields = enable_nested_fields;
+        self
+    }
+
+    /// Set symbols to index
+    #[inline]
+    pub fn symbols_to_index(mut self, symbols_to_index: Vec<String>) -> Self {
+        self.symbols_to_index = Some(symbols_to_index);
+        self
+    }
+
     /// Create a `CollectionSchema` with the current values of the builder,
     /// It can fail if any of the required fields is not not defined.
+    #[inline]
     pub fn build(self) -> CollectionSchema {
         CollectionSchema {
             name: self.name,
             fields: self.fields,
             default_sorting_field: self.default_sorting_field,
-            token_separators: None,
-            enable_nested_fields: None,
-            symbols_to_index: None,
+            token_separators: self.token_separators,
+            enable_nested_fields: self.enable_nested_fields,
+            symbols_to_index: self.symbols_to_index,
         }
     }
 }

--- a/typesense/src/collection/schema.rs
+++ b/typesense/src/collection/schema.rs
@@ -20,9 +20,10 @@ pub struct CollectionSchemaBuilder {
 impl CollectionSchemaBuilder {
     /// Create a builder for [CollectionSchema]
     #[inline]
-    pub fn new(name: impl Into<String>) -> Self {
+    pub fn new(name: impl Into<String>, fields: Vec<Field>) -> Self {
         Self {
             name: name.into(),
+            fields,
             ..Default::default()
         }
     }
@@ -43,8 +44,8 @@ impl CollectionSchemaBuilder {
 
     /// Set default sorting field
     #[inline]
-    pub fn default_sorting_field(mut self, default_sorting_field: String) -> Self {
-        self.default_sorting_field = Some(default_sorting_field);
+    pub fn default_sorting_field(mut self, default_sorting_field: impl Into<String>) -> Self {
+        self.default_sorting_field = Some(default_sorting_field.into());
         self
     }
 
@@ -93,17 +94,17 @@ mod test {
     #[test]
     fn collection_schema_serializes_as_expected() {
         let fields = [
-            ("company_name".to_owned(), "string".to_owned(), None),
-            ("num_employees".to_owned(), "int32".to_owned(), None),
-            ("country".to_owned(), "string".to_owned(), Some(true)),
+            ("company_name", "string".to_owned(), None),
+            ("num_employees", "int32".to_owned(), None),
+            ("country", "string".to_owned(), Some(true)),
         ]
         .map(|(name, typesense_type, facet)| {
             FieldBuilder::new(name, typesense_type).facet(facet).build()
-        });
+        })
+        .to_vec();
 
-        let collection = CollectionSchemaBuilder::new("companies".to_owned())
+        let collection = CollectionSchemaBuilder::new("companies", fields)
             .default_sorting_field("num_employees".to_owned())
-            .fields(&fields)
             .build();
 
         let expected = json!(

--- a/typesense/src/field/field_type.rs
+++ b/typesense/src/field/field_type.rs
@@ -1,3 +1,5 @@
+use std::collections::{BTreeMap, HashMap};
+
 /// Type for a field. Currently it is a wrapping to a `String` but it could be extended to a enum
 pub type FieldType = String;
 
@@ -11,8 +13,17 @@ pub trait ToTypesenseField {
 /// macro used internally to add implementations of ToTypesenseField for several rust types.
 #[macro_export]
 macro_rules! impl_to_typesense_field (
-    ($from:ty, $typesense_variant:expr) => {
-        impl ToTypesenseField for $from {
+    ($for:ty, $typesense_variant:expr) => {
+        impl ToTypesenseField for $for {
+            #[inline(always)]
+            fn to_typesense_type() -> &'static str {
+                $typesense_variant
+            }
+        }
+    };
+    ($for:ty, $typesense_variant:expr, $any:ident) => {
+        impl<$any> ToTypesenseField for $for {
+            #[inline(always)]
             fn to_typesense_type() -> &'static str {
                 $typesense_variant
             }
@@ -29,9 +40,17 @@ impl_to_typesense_field!(usize, "int64");
 impl_to_typesense_field!(f32, "float");
 impl_to_typesense_field!(f64, "float");
 impl_to_typesense_field!(bool, "bool");
+impl_to_typesense_field!(HashMap<String, T>, "object", T);
+impl_to_typesense_field!(BTreeMap<String, T>, "object", T);
+
 impl_to_typesense_field!(Vec<String>, "string[]");
+impl_to_typesense_field!(Vec<u8>, "int32[]");
 impl_to_typesense_field!(Vec<i32>, "int32[]");
 impl_to_typesense_field!(Vec<i64>, "int64[]");
+impl_to_typesense_field!(Vec<u32>, "int64[]");
+impl_to_typesense_field!(Vec<usize>, "int64[]");
 impl_to_typesense_field!(Vec<f32>, "float[]");
 impl_to_typesense_field!(Vec<f64>, "float[]");
 impl_to_typesense_field!(Vec<bool>, "bool[]");
+impl_to_typesense_field!(Vec<HashMap<String, T>>, "object[]", T);
+impl_to_typesense_field!(Vec<BTreeMap<String, T>>, "object[]", T);

--- a/typesense/src/field/mod.rs
+++ b/typesense/src/field/mod.rs
@@ -24,6 +24,7 @@ pub struct FieldBuilder {
 
 impl FieldBuilder {
     /// Create a Builder
+    #[inline]
     pub fn new(name: impl Into<String>, typesense_type: FieldType) -> Self {
         Self {
             name: name.into(),
@@ -32,50 +33,65 @@ impl FieldBuilder {
         }
     }
 
-    /// Set if field is facet.
-    pub fn facet(mut self, facet: Option<bool>) -> Self {
-        self.facet = facet;
-        self
-    }
-
     /// Set if field is optional.
+    #[inline]
     pub fn optional(mut self, optional: Option<bool>) -> Self {
         self.optional = optional;
         self
     }
 
+    /// Set if field is facet.
+    #[inline]
+    pub fn facet(mut self, facet: Option<bool>) -> Self {
+        self.facet = facet;
+        self
+    }
+
     /// Set if field is index.
+    #[inline]
     pub fn index(mut self, index: Option<bool>) -> Self {
         self.index = index;
         self
     }
 
     /// Set field locale.
+    #[inline]
     pub fn locale(mut self, locale: Option<String>) -> Self {
         self.locale = locale;
         self
     }
 
-    /// Set sort attribute from field
+    /// Set sort attribute for field
+    #[inline]
     pub fn sort(mut self, sort: Option<bool>) -> Self {
         self.sort = sort;
         self
     }
 
-    /// Set drop attribute from field
-    pub fn drop(mut self, drop: Option<bool>) -> Self {
-        self.drop = drop;
-        self
-    }
-
-    /// Set infix attribute from field
+    /// Set infix attribute for field
+    #[inline]
     pub fn infix(mut self, infix: Option<bool>) -> Self {
         self.infix = infix;
         self
     }
 
+    /// Set num_dim attribute for field
+    #[inline]
+    pub fn num_dim(mut self, num_dim: Option<i32>) -> Self {
+        self.num_dim = num_dim;
+        self
+    }
+
+    /// Set drop attribute for field
+    #[inline]
+    pub fn drop(mut self, drop: Option<bool>) -> Self {
+        self.drop = drop;
+        self
+    }
+
     /// Create a `Field` with the current values of the builder,
     /// It can fail if the name or the typesense_type are not defined.
+    #[inline]
     pub fn build(self) -> Field {
         Field {
             name: self.name,

--- a/typesense/src/transport/mod.rs
+++ b/typesense/src/transport/mod.rs
@@ -21,6 +21,7 @@ pub struct Transport<C> {
 
 #[cfg(all(feature = "tokio-rt", not(target_arch = "wasm32")))]
 impl Default for Transport<HyperHttpsClient> {
+    #[inline]
     fn default() -> Self {
         Transport::new()
     }
@@ -42,7 +43,7 @@ where
     }
 }
 
-#[allow(missing_docs)]
+#[doc(hidden)]
 pub trait TransportCreator {
     /// Create new Transport
     fn new() -> Self;
@@ -68,6 +69,7 @@ impl TransportCreator for Transport<HyperHttpsClient> {
 #[cfg_attr(docsrs, doc(cfg(target_arch = "wasm32")))]
 impl TransportCreator for Transport<WasmClient> {
     /// Used to make a new wasm client.
+    #[inline]
     fn new() -> Self {
         Self {
             client: http_low_level::WasmClient,

--- a/typesense/tests/collection_client.rs
+++ b/typesense/tests/collection_client.rs
@@ -86,8 +86,7 @@ mod hyper_tests {
 
 #[allow(dead_code)]
 #[derive(Document, Serialize, Deserialize)]
-#[typesense(default_sorting_field = "num_employees")]
-#[typesense(collection_name = "companies")]
+#[typesense(collection_name = "companies", default_sorting_field = "num_employees")]
 struct Company {
     company_name: String,
     num_employees: i32,

--- a/typesense/tests/derive/collection.rs
+++ b/typesense/tests/derive/collection.rs
@@ -29,7 +29,8 @@ fn derived_document_generates_schema() {
                 "optional" :  true
               }
             ],
-            "default_sorting_field": "num_employees"
+            "default_sorting_field": "num_employees",
+            "enable_nested_fields": true
           }
     );
 
@@ -38,8 +39,11 @@ fn derived_document_generates_schema() {
 
 #[allow(dead_code)]
 #[derive(Document, Serialize, Deserialize)]
-#[typesense(default_sorting_field = "num_employees")]
-#[typesense(collection_name = "companies")]
+#[typesense(
+    collection_name = "companies",
+    default_sorting_field = "num_employees",
+    enable_nested_fields = true
+)]
 struct Company {
     company_name: String,
     num_employees: i32,

--- a/typesense/tests/derive/ui/non_strliteral_default_field.stderr
+++ b/typesense/tests/derive/ui/non_strliteral_default_field.stderr
@@ -1,4 +1,4 @@
-error: Expected string literal, do you mean "company_name"?
+error: Expected string literal, did you mean "company_name"?
  --> $DIR/non_strliteral_default_field.rs:5:37
   |
 5 | #[typesense(default_sorting_field = company_name)]

--- a/typesense/tests/derive/ui/unknown_attribute.stderr
+++ b/typesense/tests/derive/ui/unknown_attribute.stderr
@@ -1,4 +1,4 @@
-error: Unexpected token facets. Do you mean `facet`?
+error: Unexpected token facets. Did you mean `facet`?
  --> $DIR/unknown_attribute.rs:8:17
   |
 8 |     #[typesense(facets)]

--- a/typesense/tests/derive/ui/wrong_sorting_field.stderr
+++ b/typesense/tests/derive/ui/wrong_sorting_field.stderr
@@ -1,4 +1,4 @@
-error: defined default_sorting_field does not match with any field.
+error: defined default_sorting_field = "wrong_field" does not match with any field.
   --> $DIR/wrong_sorting_field.rs:5:1
    |
 5  | / #[typesense(default_sorting_field = "wrong_field")]

--- a/typesense/webdriver.json
+++ b/typesense/webdriver.json
@@ -1,0 +1,7 @@
+{
+    "goog:chromeOptions": {
+        "args": [
+            "disable-web-security"
+        ]
+    }
+}

--- a/typesense_codegen/Cargo.toml
+++ b/typesense_codegen/Cargo.toml
@@ -12,6 +12,7 @@ serde_derive = "^1.0"
 serde_json = "^1.0"
 url = "^2.2"
 uuid = { version = "^1.0", features = ["serde", "v4", "js"] }
+
 [dependencies.reqwest]
 version = "^0.11"
 features = ["json", "multipart"]

--- a/typesense_derive/src/lib.rs
+++ b/typesense_derive/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, TokenTree};
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{spanned::Spanned, Attribute, Field, ItemStruct};
 
 #[proc_macro_derive(Document, attributes(typesense))]
@@ -12,7 +12,7 @@ pub fn typesense_collection_derive(input: TokenStream) -> TokenStream {
 }
 
 fn impl_typesense_collection(item: ItemStruct) -> syn::Result<TokenStream> {
-    let span = item.span();
+    let item_ts = item.to_token_stream();
 
     let ItemStruct {
         attrs,
@@ -48,8 +48,8 @@ fn impl_typesense_collection(item: ItemStruct) -> syn::Result<TokenStream> {
                 // At this point we are sure that this field is a named field.
                 field.ident.as_ref().unwrap() == sorting_field)
         {
-            return Err(syn::Error::new(
-                span,
+            return Err(syn::Error::new_spanned(
+                item_ts,
                 format!(
                     "defined default_sorting_field = \"{}\" does not match with any field.",
                     sorting_field

--- a/typesense_derive/src/lib.rs
+++ b/typesense_derive/src/lib.rs
@@ -65,7 +65,7 @@ fn impl_typesense_collection(item: ItemStruct) -> syn::Result<TokenStream> {
 
     let default_sorting_field = if let Some(v) = default_sorting_field {
         quote! {
-            builder = builder.default_sorting_field(std::string::String::from(#v));
+            builder = builder.default_sorting_field(#v);
         }
     } else {
         proc_macro2::TokenStream::new()
@@ -83,9 +83,9 @@ fn impl_typesense_collection(item: ItemStruct) -> syn::Result<TokenStream> {
         impl #impl_generics typesense::document::Document for #ident #ty_generics #where_clause {
             fn collection_schema() -> typesense::collection::CollectionSchema {
                 let name = #collection_name.to_owned();
-                let fields = &[#(#typesense_fields,)*];
+                let fields = vec![#(#typesense_fields,)*];
 
-                let mut builder = typesense::collection::CollectionSchemaBuilder::new(name).fields(fields);
+                let mut builder = typesense::collection::CollectionSchemaBuilder::new(name, fields);
 
                 #default_sorting_field
                 #enable_nested_fields


### PR DESCRIPTION
## Change Summary
Proc macro in `typesense_derive` was updated to support this:
```
#[typesense(
    collection_name = "companies",
    default_sorting_field = "num_employees",
    enable_nested_fields = true
)]
```
instead of this:
```
#[typesense(default_sorting_field = "num_employees")]
#[typesense(collection_name = "companies")]
```