### PR TITLE
fix: remove unsafe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ anyhow = "1"
 base64 = "0.22"
 bon = "3"
 clap = { version = "4", features = ["derive"] }
-debug_unsafe = "0.1"
 hmac = "0.12"
 reqwest-retry = "0.7"
 serde = { version = "1", features = ["derive"] }

--- a/typesense/Cargo.toml
+++ b/typesense/Cargo.toml
@@ -22,7 +22,6 @@ typesense_derive = { workspace = true, optional = true }
 anyhow = { workspace = true }
 base64 = { workspace = true }
 bon = { workspace = true }
-debug_unsafe = { workspace = true }
 hmac = { workspace = true }
 reqwest-retry = { workspace = true }
 serde = { workspace = true }

--- a/typesense/src/client/mod.rs
+++ b/typesense/src/client/mod.rs
@@ -142,7 +142,6 @@ use reqwest_middleware::ClientBuilder as ReqwestMiddlewareClientBuilder;
 use reqwest_retry::RetryTransientMiddleware;
 pub use reqwest_retry::policies::ExponentialBackoff;
 
-use debug_unsafe::{option::OptionUnwrapper, slice::SliceGetter};
 use serde::{Serialize, de::DeserializeOwned};
 use std::{
     future::Future,
@@ -257,7 +256,7 @@ impl Client {
                 .with(RetryTransientMiddleware::new_with_policy(retry_policy))
                 .build();
 
-                if url.len() > 1 && url.chars().last().unwrap_safe_unchecked() == '/' {
+                if url.len() > 1 && matches!(url.chars().last(), Some('/')) {
                     url.pop();
                 }
 
@@ -294,8 +293,10 @@ impl Client {
     /// Selects the next node to use for a request based on health and priority.
     fn get_next_node(&self) -> &Node {
         // if only one node (including nearest)
-        if self.nodes.len() == 1 {
-            return self.nodes.first().unwrap_safe_unchecked();
+        if self.nodes.len() == 1
+            && let Some(first) = self.nodes.first()
+        {
+            return first;
         }
 
         let (nodes_len, mut index) = if self.is_nearest_node_set {
@@ -309,7 +310,7 @@ impl Client {
         };
 
         for _ in 0..self.nodes.len() {
-            let node = self.nodes.get_safe_unchecked(index);
+            let node = &self.nodes[index];
 
             if node.is_healthy.load(Ordering::Relaxed)
                 || node.last_accessed.read().unwrap().elapsed() >= self.healthcheck_interval
@@ -322,7 +323,7 @@ impl Client {
         // If all nodes are unhealthy and not due for a check, just pick the next one in the round-robin.
         // This gives it a chance to prove it has recovered.
         index = self.current_node_index.load(Ordering::Relaxed) % self.nodes.len();
-        self.nodes.get_safe_unchecked(index)
+        &self.nodes[index]
     }
 
     /// For use in legacy APIs.


### PR DESCRIPTION
## Change Summary

Going through the new code, found out `unsafe` is being used directly 😬 This is a proposal to remove the `usafe` usage in order to provide higher security and fault-tolerance guarantees. I don't believe any performance is meaningfully lost here. I believe the difference amounts to at most one bounds check in a non-hot path.


## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).

^ I will be sure to sign the CLA if the PR gets reviewed and will be on track for merging...