### PR TITLE
Feat: use inner `<T as ToTypesenseField>::to_typesense_type()` of `Vec<T>` in derive

### DIFF
--- a/typesense/src/traits/field_type.rs
+++ b/typesense/src/traits/field_type.rs
@@ -17,21 +17,6 @@ impl<T: Document> ToTypesenseField for T {
     }
 }
 
-/// Generic implementation for a Vec of any type that is also a Typesense document.
-impl<T: Document> ToTypesenseField for Vec<T> {
-    #[inline(always)]
-    fn to_typesense_type() -> &'static str {
-        "object[]"
-    }
-}
-
-impl<T: ToTypesenseField> ToTypesenseField for Option<T> {
-    #[inline(always)]
-    fn to_typesense_type() -> &'static str {
-        T::to_typesense_type()
-    }
-}
-
 /// macro used internally to add implementations of ToTypesenseField for several rust types.
 #[macro_export]
 macro_rules! impl_to_typesense_field (
@@ -42,18 +27,6 @@ macro_rules! impl_to_typesense_field (
                 $typesense_type
             }
         }
-        impl $crate::prelude::ToTypesenseField for Vec<$for> {
-            #[inline(always)]
-            fn to_typesense_type() -> &'static str {
-                concat!($typesense_type, "[]")
-            }
-        }
-        impl $crate::prelude::ToTypesenseField for Vec<Option<$for>> {
-            #[inline(always)]
-            fn to_typesense_type() -> &'static str {
-                concat!($typesense_type, "[]")
-            }
-        }
     };
 
     ($for:ty, $typesense_type:expr, $any:ident $(: $any_bound:path)?) => {
@@ -61,18 +34,6 @@ macro_rules! impl_to_typesense_field (
             #[inline(always)]
             fn to_typesense_type() -> &'static str {
                 $typesense_type
-            }
-        }
-        impl<$any $(: $any_bound)?> $crate::prelude::ToTypesenseField for Vec<$for> {
-            #[inline(always)]
-            fn to_typesense_type() -> &'static str {
-                concat!($typesense_type, "[]")
-            }
-        }
-        impl<$any $(: $any_bound)?> $crate::prelude::ToTypesenseField for Vec<Option<$for>> {
-            #[inline(always)]
-            fn to_typesense_type() -> &'static str {
-                concat!($typesense_type, "[]")
             }
         }
     };

--- a/typesense/tests/client/derive_integration_test.rs
+++ b/typesense/tests/client/derive_integration_test.rs
@@ -54,6 +54,19 @@ struct Manufacturer {
     city: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum Priority {
+    Low,
+    Medium,
+    High,
+}
+
+impl ToTypesenseField for Priority {
+    fn to_typesense_type() -> &'static str {
+        "string"
+    }
+}
+
 /// The main struct that uses every feature of the derive macro.
 #[derive(Typesense, Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[typesense(
@@ -104,6 +117,12 @@ struct MegaProduct {
     parts: Vec<Part>,
 
     tags: Option<Vec<String>>,
+
+    priority: Option<Priority>,
+
+    priorities: Vec<Priority>,
+
+    priorities_opt: Vec<Option<Priority>>,
 
     #[typesense(rename = "primary_address.city")]
     #[serde(rename = "primary_address.city")]
@@ -247,6 +266,24 @@ async fn logic_test_derive_macro_with_generic_client_lifecycle() {
                 assert_eq!(
                     actual_field.r#type, "string[]",
                     "Field 'tags' should have type 'string[]'"
+                );
+            }
+            "priority" => {
+                assert_eq!(
+                    actual_field.r#type, "string",
+                    "Field 'priority' should have type 'string[]'"
+                );
+            }
+            "priorities" => {
+                assert_eq!(
+                    actual_field.r#type, "string[]",
+                    "Field 'priorities' should have type 'string[]'"
+                );
+            }
+            "priorities_opt" => {
+                assert_eq!(
+                    actual_field.r#type, "string[]",
+                    "Field 'priorities_opt' should have type 'string[]'"
                 );
             }
             "details" => {
@@ -413,6 +450,9 @@ async fn logic_test_derive_macro_with_generic_client_lifecycle() {
             },
         ],
         tags: Some(vec!["steel".to_owned(), "heavy-duty".to_owned()]),
+        priority: Some(Priority::Low),
+        priorities: vec![Priority::Low],
+        priorities_opt: vec![Some(Priority::Low)],
         primary_city: "City".to_owned(),
         locale: "Xin chào!".to_owned(),
         qty: 123,
@@ -542,6 +582,9 @@ async fn logic_test_derive_macro_with_generic_client_lifecycle() {
     let update_payload = MegaProductPartial {
         price: Some(25.99),
         tags: Some(Some(vec!["steel".to_owned(), "sale".to_owned()])),
+        priority: Some(Some(Priority::Medium)),
+        priorities: Some(vec![Priority::Medium]),
+        priorities_opt: Some(vec![Some(Priority::Medium)]),
         ..Default::default()
     };
 
@@ -562,6 +605,9 @@ async fn logic_test_derive_macro_with_generic_client_lifecycle() {
         updated_product.tags,
         Some(vec!["steel".to_owned(), "sale".to_owned()])
     );
+    assert_eq!(updated_product.priority, Some(Priority::Medium));
+    assert_eq!(updated_product.priorities, vec![Priority::Medium]);
+    assert_eq!(updated_product.priorities_opt, vec![Some(Priority::Medium)]);
     assert_eq!(updated_product.title, product1.title); // Unchanged field
 
     //  Delete Document

--- a/typesense_derive/src/field_attributes.rs
+++ b/typesense_derive/src/field_attributes.rs
@@ -271,6 +271,16 @@ fn build_regular_field(field: &Field, field_attrs: &FieldAttributes) -> proc_mac
         (&field.ty, false)
     };
 
+    // Peel `Vec<_>` (and `Vec<Option<_>>`) so `ToTypesenseField` resolves on
+    // the element type and `"[]"` is appended at runtime. Lets downstream
+    // crates use local element types without hitting orphan rules.
+    let (ty, is_vec) = if let Some(vec_inner) = ty_inner_type(ty, "Vec") {
+        let inner = ty_inner_type(vec_inner, "Option").unwrap_or(vec_inner);
+        (inner, true)
+    } else {
+        (ty, false)
+    };
+
     let field_name = if let Some(rename) = &field_attrs.rename {
         quote! { #rename }
     } else {
@@ -279,9 +289,16 @@ fn build_regular_field(field: &Field, field_attrs: &FieldAttributes) -> proc_mac
     };
 
     let typesense_field_type = if let Some(override_str) = &field_attrs.type_override {
-        quote! { #override_str }
+        quote! { ::std::string::String::from(#override_str) }
+    } else if is_vec {
+        quote! {
+            format!(
+                "{}[]",
+                <#ty as ::typesense::prelude::ToTypesenseField>::to_typesense_type()
+            )
+        }
     } else {
-        quote! { <#ty as ::typesense::prelude::ToTypesenseField>::to_typesense_type() }
+        quote! { <#ty as ::typesense::prelude::ToTypesenseField>::to_typesense_type().to_owned() }
     };
 
     let optional = field_attrs


### PR DESCRIPTION
## Change Summary
                                                                           
Deriving Typesense on a struct with a `Vec<MyLocalType>` field only compiles if `MyLocalType: Document` (giving "object[]") or is a built-in primitive. And we cannot do `impl ToTypesenseField for Vec<MyLocalType>` in downstream crates, so requires the `#[typesense(type = "...")]` per-field work around.

This PR mirrors what `build_regular_field` already does for flatten: peel Vec<\_> (and Vec<Option<\_>>) in the proc-macro, resolve `ToTypesenseField` on the inner type, and append `"[]"`. Downstream crates now only need `MyLocalType: ToTypesenseField`.

Example that compiles after this PR but not before:                   

```rust
 use serde::{Serialize, Deserialize};                                      
 use typesense::{Typesense, prelude::ToTypesenseField};  
                                                                           
 #[derive(Serialize, Deserialize)]                       
 pub enum Priority { Low, Medium, High }                                   
                                                                           
 impl ToTypesenseField for Priority {
     fn to_typesense_type() -> &'static str { "string" }                   
 }                                                                         

 #[derive(Typesense, Serialize, Deserialize)]                              
 struct Task {                                           
     priority: Priority,        // "string"      (worked before)           
     status: Option<Priority>,  // "string"      (worked before)
     tags: Vec<Priority>,       // "string[]"    (NEW: required #[typesense(type = "string[]")] before)                                   
 }                                                                         
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
