### PR TITLE
Don't require Serialize when reading from a collection

### DIFF
--- a/preprocessed_openapi.yml
+++ b/preprocessed_openapi.yml
@@ -859,7 +859,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
-      x-rust-generic-parameter: 'D: for<''de> serde::Deserialize<''de> + Serialize'
+      x-rust-generic-parameter: 'D: for<''de> serde::Deserialize<''de>'
       x-rust-return-type: models::SearchResult<D>
       x-rust-has-lifetime: true
   /synonym_sets:

--- a/typesense/src/client/collection/document.rs
+++ b/typesense/src/client/collection/document.rs
@@ -6,18 +6,19 @@
 
 use crate::{Client, Error, execute_wrapper, traits};
 use ::std::borrow::Cow;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::de::DeserializeOwned;
 use typesense_codegen::apis::documents_api;
 
 /// Provides methods for interacting with a single document within a specific Typesense collection.
 ///
 /// This struct is created by calling a method like `client.collection_schemaless("collection_name").document("document_id")`
 /// or `client.collection::<MyType>().document("document_id")`.
-/// The generic `D` represents the shape of the document and must implement `Serialize` and `DeserializeOwned`.
+/// The generic `D` represents the shape of the document and must implement `DeserializeOwned`.
+/// Write operations require `D: Document`, which additionally requires `Serialize`.
 /// If `D` is not specified, it defaults to `serde_json::Value` for schemaless interactions.
 pub struct Document<'d, D = serde_json::Value>
 where
-    D: DeserializeOwned + Serialize,
+    D: DeserializeOwned,
 {
     client: &'d Client,
     collection_name: &'d str,
@@ -27,7 +28,7 @@ where
 
 impl<'d, D> Document<'d, D>
 where
-    D: DeserializeOwned + Serialize,
+    D: DeserializeOwned,
 {
     /// Creates a new `Document` instance for a specific document ID.
     #[inline]

--- a/typesense/src/client/collection/documents.rs
+++ b/typesense/src/client/collection/documents.rs
@@ -10,7 +10,7 @@ use crate::{
     traits,
 };
 use ::std::borrow::Cow;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::de::DeserializeOwned;
 use typesense_codegen::{
     apis::documents_api,
     models::{
@@ -25,7 +25,7 @@ use typesense_codegen::{
 /// `D` will be `MyType`.
 pub struct Documents<'d, D = serde_json::Value>
 where
-    D: DeserializeOwned + Serialize,
+    D: DeserializeOwned,
 {
     client: &'d Client,
     collection_name: &'d str,
@@ -34,7 +34,7 @@ where
 
 impl<'d, D> Documents<'d, D>
 where
-    D: DeserializeOwned + Serialize,
+    D: DeserializeOwned,
 {
     /// Creates a new `Documents` instance.
     #[inline]

--- a/typesense/src/client/collection/mod.rs
+++ b/typesense/src/client/collection/mod.rs
@@ -7,7 +7,7 @@ mod documents;
 
 use crate::{Client, Error, execute_wrapper};
 use ::std::borrow::Cow;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::de::DeserializeOwned;
 use typesense_codegen::{apis::collections_api, models};
 
 /// Provides methods for interacting with a Typesense collection.
@@ -15,7 +15,7 @@ use typesense_codegen::{apis::collections_api, models};
 /// This struct is created by calling `client.collection()`.
 pub struct Collection<'c, D = serde_json::Value>
 where
-    D: DeserializeOwned + Serialize,
+    D: DeserializeOwned,
 {
     client: &'c Client,
     collection_name: Cow<'c, str>,
@@ -24,7 +24,7 @@ where
 
 impl<'c, D> Collection<'c, D>
 where
-    D: DeserializeOwned + Serialize,
+    D: DeserializeOwned,
 {
     /// Creates a new `Collection` instance.
     #[inline]

--- a/typesense/src/client/mod.rs
+++ b/typesense/src/client/mod.rs
@@ -159,7 +159,7 @@ use ::std::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
-use serde::{Serialize, de::DeserializeOwned};
+use serde::de::DeserializeOwned;
 use typesense_codegen::apis::{self, configuration};
 use web_time::{Duration, Instant};
 
@@ -629,7 +629,8 @@ impl Client {
     /// stored in that collection.
     ///
     /// # Type Parameters
-    /// * `D` - The type of the documents in the collection. It must be serializable and deserializable.
+    /// * `D` - The type of the documents in the collection. It must implement `DeserializeOwned`.
+    ///   Write operations (e.g. `create`, `upsert`, `update`) additionally require `D: Document`.
     ///
     /// # Arguments
     /// * `collection_name` - The name of the collection to interact with.
@@ -642,9 +643,9 @@ impl Client {
     /// # #[cfg(not(target_family = "wasm"))]
     /// # {
     /// # use typesense::Client;
-    /// # use serde::{Serialize, Deserialize};
+    /// # use serde::Deserialize;
     /// #
-    /// # #[derive(Serialize, Deserialize, Debug)]
+    /// # #[derive(Deserialize, Debug)]
     /// # struct Book { id: String, title: String }
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::builder()
@@ -652,7 +653,7 @@ impl Client {
     /// #    .api_key("xyz")
     /// #    .build()
     /// #    .unwrap();
-    /// // Get a typed handle to the "books" collection
+    /// // Get a typed handle to the "books" collection (Deserialize is enough for reads)
     /// let books_collection = client.collection_named::<Book>("books");
     ///
     /// // Retrieve a single book, it returns `Result<Book, ...>`
@@ -669,7 +670,7 @@ impl Client {
         collection_name: impl Into<Cow<'c, str>>,
     ) -> Collection<'c, D>
     where
-        D: DeserializeOwned + Serialize,
+        D: DeserializeOwned,
     {
         Collection::new(self, collection_name)
     }
@@ -680,7 +681,7 @@ impl Client {
     /// stored in that collection.
     ///
     /// # Type Parameters
-    /// * `D` - The type of the documents in the collection. It must be of trait Document.
+    /// * `D` - The type of the documents in the collection. It must implement the [`Document`] trait.
     ///
     /// # Example: Working with a strongly-typed collection
     ///

--- a/typesense_codegen/src/apis/documents_api.rs
+++ b/typesense_codegen/src/apis/documents_api.rs
@@ -1019,7 +1019,7 @@ pub async fn multi_search(
 }
 
 /// Search for documents in a collection that match the search criteria.
-pub async fn search_collection<D: for<'de> serde::Deserialize<'de> + Serialize>(
+pub async fn search_collection<D: for<'de> serde::Deserialize<'de>>(
     configuration: &configuration::Configuration,
     params: &SearchCollectionParams<'_>,
 ) -> Result<models::SearchResult<D>, Error<SearchCollectionError>> {

--- a/xtask/src/add_vendor_attributes.rs
+++ b/xtask/src/add_vendor_attributes.rs
@@ -41,7 +41,7 @@ pub fn add_vendor_attributes(doc: &mut OpenAPI) -> Result<(), String> {
     // Operations
     attrs
         .operation("/collections/{collectionName}/documents/search", "get")
-        .generic_parameter("D: for<'de> serde::Deserialize<'de> + Serialize")?
+        .generic_parameter("D: for<'de> serde::Deserialize<'de>")?
         .return_type("models::SearchResult<D>")?;
 
     attrs


### PR DESCRIPTION
## Change Summary
When using `collection_named` it should be possible to use the read methods without requiring to have the Serialize trait implementation.

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
